### PR TITLE
Add start.sh script

### DIFF
--- a/dpa/start.sh
+++ b/dpa/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Jock! Start the engine!
+/app/dpa_${VERSION_}/startup.sh
+
+# Touch to update inode, just in case tomcat hasn't written to it yet.
+touch /app/dpa_${VERSION_}/iwc/tomcat/logs/catalina.out
+
+# Print the contents of the Tomcat catalina.out log on stdout.
+exec tail -f  /app/dpa_${VERSION_}/iwc/tomcat/logs/catalina.out


### PR DESCRIPTION
Add start.sh script, that uses the VERSION_ environment variable to find the installation, and runs tail -f exec'd to make sure it gets any signals (ie Ctrl-C/SIGTERM).